### PR TITLE
Add pytest tests for extrair functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,12 @@ Mais informações sobre como utilizar a API do SIDRA estão disponíveis na [[d
 ---
 
 Essas bases fornecem a sustentação estatística para as análises e visualizações desenvolvidas neste projeto.
+
+## Executando os testes
+
+Os testes automatizados utilizam `pytest`. Para executá-los, instale o pacote e rode o comando a seguir na raiz do projeto:
+
+```bash
+pip install pytest
+pytest
+```

--- a/Script DML carregar base sidra_mysql.py
+++ b/Script DML carregar base sidra_mysql.py
@@ -16,10 +16,6 @@ def conectar_mysql():
         print(f"Erro ao conectar ao MySQL: {err}")
         exit(1)
 
-# Inicia conexão
-conn = conectar_mysql()
-cursor = conn.cursor()
-
 # Lista de consultas SIDRA e tabelas MySQL correspondentes
 consultas = [
     {
@@ -78,31 +74,39 @@ consultas = [
     }
 ]
 
-# Processa todas as consultas
-for consulta in consultas:
-    print(f"\n📦 Consultando {consulta['tabela']}...")
-    try:
-        resp = requests.get(consulta["url"])
-        data = resp.json()
+def main():
+    conn = conectar_mysql()
+    cursor = conn.cursor()
 
-        inseridos, nulos = 0, 0
-        for record in data[1:]:
-            try:
-                valores = consulta["extrair"](record)
-                if valores[0] is None:
-                    nulos += 1
-                cursor.execute(consulta["sql"], valores)
-                inseridos += cursor.rowcount
-            except Exception as e:
-                print(f"⚠️ Erro ao processar registro: {e}")
-                continue
+    # Processa todas as consultas
+    for consulta in consultas:
+        print(f"\n📦 Consultando {consulta['tabela']}...")
+        try:
+            resp = requests.get(consulta["url"])
+            data = resp.json()
 
-        print(f"✅ {consulta['tabela']}: {inseridos} inseridos, {nulos} valores NULL.")
-    except Exception as e:
-        print(f"❌ Erro ao consultar {consulta['url']}: {e}")
+            inseridos, nulos = 0, 0
+            for record in data[1:]:
+                try:
+                    valores = consulta["extrair"](record)
+                    if valores[0] is None:
+                        nulos += 1
+                    cursor.execute(consulta["sql"], valores)
+                    inseridos += cursor.rowcount
+                except Exception as e:
+                    print(f"⚠️ Erro ao processar registro: {e}")
+                    continue
 
-# Finaliza conexão
-conn.commit()
-cursor.close()
-conn.close()
-print("\n🔌 Conexão finalizada.")
+            print(f"✅ {consulta['tabela']}: {inseridos} inseridos, {nulos} valores NULL.")
+        except Exception as e:
+            print(f"❌ Erro ao consultar {consulta['url']}: {e}")
+
+    # Finaliza conexão
+    conn.commit()
+    cursor.close()
+    conn.close()
+    print("\n🔌 Conexão finalizada.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_extrair.py
+++ b/tests/test_extrair.py
@@ -1,0 +1,69 @@
+import importlib.util
+from pathlib import Path
+import types
+import sys
+
+# Carrega o módulo de consultas sem executá-lo como script
+spec = importlib.util.spec_from_file_location(
+    "sidra_script",
+    Path(__file__).resolve().parents[1] / "Script DML carregar base sidra_mysql.py",
+)
+mod = importlib.util.module_from_spec(spec)
+# Cria stubs para dependências externas ausentes
+sys.modules.setdefault("requests", types.ModuleType("requests"))
+sys.modules.setdefault("mysql", types.ModuleType("mysql"))
+sys.modules.setdefault("mysql.connector", types.ModuleType("mysql.connector"))
+spec.loader.exec_module(mod)
+
+consultas = mod.consultas
+
+
+def test_extrair_8880_valor_convertido():
+    extrair = consultas[0]["extrair"]
+    registro = {"V": "10.5", "D2N": "ind", "D3N": "uf", "D4C": "202301", "D4N": "Jan"}
+    assert extrair(registro) == (10.5, "ind", "uf", "202301", "Jan")
+
+
+def test_extrair_8880_valor_vazio():
+    extrair = consultas[0]["extrair"]
+    registro = {"V": "", "D2N": "ind", "D3N": "uf", "D4C": "202301", "D4N": "Jan"}
+    assert extrair(registro)[0] is None
+
+
+def test_extrair_8881_converte_int():
+    extrair = consultas[1]["extrair"]
+    registro = {"V": "1", "D2N": "ind", "D3N": "uf", "D4C": "202301", "D4N": "Jan"}
+    resultado = extrair(registro)
+    assert resultado == (1.0, "ind", "uf", 202301, "Jan")
+
+
+def test_extrair_8881_valor_vazio():
+    extrair = consultas[1]["extrair"]
+    registro = {"V": "", "D2N": "ind", "D3N": "uf", "D4C": "202301", "D4N": "Jan"}
+    assert extrair(registro)[0] is None
+
+
+def test_extrair_8882_campos():
+    extrair = consultas[2]["extrair"]
+    registro = {
+        "V": "2",
+        "D2N": "ind",
+        "D3N": "ativ",
+        "D4N": "uf",
+        "D5C": "cod",
+        "D5N": "mes",
+    }
+    assert extrair(registro) == (2.0, "ind", "ativ", "uf", "cod", "mes")
+
+
+def test_extrair_8883_valor_vazio():
+    extrair = consultas[3]["extrair"]
+    registro = {
+        "V": "",
+        "D2N": "ind",
+        "D3N": "ativ",
+        "D4N": "uf",
+        "D5C": "cod",
+        "D5N": "mes",
+    }
+    assert extrair(registro)[0] is None


### PR DESCRIPTION
## Summary
- allow importing the ETL script without running it by wrapping logic in `main`
- add pytest tests covering the `extrair` lambdas
- document how to run the tests in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a1f40919c8333bef8c96072093fde