### PR TITLE
Use environment variables for MySQL credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Linguagem de programação utilizada para a automação dos processos de **extra
   - Baixar o arquivo "Script DML carregar base sidra_mysql.py" do repositório (https://github.com/valdecircarlos/PI_Senac/blob/main/Script%20DML%20carregar%20base%20sidra_mysql.py)
   - Abra o Prompt de Comando do Windows
   - Acesse o Diretório onde o arquivo de Script "Script DML carregar base sidra_mysql.py" foi salvo.
+  - Configure as variáveis de ambiente `MYSQL_HOST`, `MYSQL_USER`, `MYSQL_PASSWORD` e `MYSQL_DATABASE` com as credenciais do MySQL.
   - Executar o "Script DML carregar base sidra_mysql.py" no Prompt de comando
 
 ---

--- a/Script DML carregar base sidra_mysql.py
+++ b/Script DML carregar base sidra_mysql.py
@@ -1,3 +1,4 @@
+import os
 import requests
 import mysql.connector
 
@@ -5,10 +6,10 @@ import mysql.connector
 def conectar_mysql():
     try:
         conn = mysql.connector.connect(
-            host="127.0.0.1",
-            user="root",
-            password="G@mes8090",
-            database="sidra"
+            host=os.environ.get("MYSQL_HOST", "127.0.0.1"),
+            user=os.environ.get("MYSQL_USER", "root"),
+            password=os.environ.get("MYSQL_PASSWORD", "G@mes8090"),
+            database=os.environ.get("MYSQL_DATABASE", "sidra"),
         )
         print("✅ Conectado ao MySQL com sucesso.")
         return conn


### PR DESCRIPTION
## Summary
- load MySQL connection info from environment variables in the loader script
- document the required variables in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687320a38d04833394c39acfcee94f83