### PR TITLE
Corrige links e instruções no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Sistema de gerenciamento de banco de dados relacional (SGBDR), utilizado como re
   - [MySQL Workbench](https://www.mysql.com/products/workbench/)
 
 - **Criação da Base de Dados do MySQL para receber os dados do SIDRA:**
-  - Baixar o arquivo "Script DDL base de dados sidra.sql" do repositório (https://github.com/valdecircarlos/PI_Senac/blob/main/Script%20DDL%20base%20de%20dados%20sidra.sql)
+  - Baixar o arquivo ["Script DDL base de dados sidra.sql"](https://github.com/valdecircarlos/PI_Senac/blob/main/Script%20DDL%20base%20de%20dados%20sidra.sql)
   - Abra o MySQL Workbench
   - Abrir o arquivo "Script DDL base de dados sidra.sql" no botão "Open SQL Script" 
   - Execute os comandos carregados.
@@ -24,11 +24,11 @@ Ferramenta de visualização de dados utilizada para a criação de dashboards i
 
 - **Instalação:**  
   Baixe e instale o Power BI Desktop a partir do site oficial ou da Microsoft Store.  
-  [[Download Power BI Desktop](https://powerbi.microsoft.com/desktop](https://www.microsoft.com/pt-br/download/details.aspx?id=58494)
+  [Download Power BI Desktop](https://powerbi.microsoft.com/desktop)
 
 - **Principais funcionalidades utilizadas:**  
   - Conexão com fontes de dados MySQL
-     *Usando o conector "mysql-connector-net-9.3.0.msi" [Download] (https://dev.mysql.com/downloads/connector/net/)*
+     *Usando o conector "mysql-connector-net-9.3.0.msi" [Download](https://dev.mysql.com/downloads/connector/net/)*
   - Criação de medidas DAX  
   - Filtros interativos e segmentações  
 
@@ -60,11 +60,11 @@ Linguagem de programação utilizada para a automação dos processos de **extra
 - **Instalação das Bibliotecas no Windows:**
   - Abra o Prompt de Comando do Windows
   - python --version  (para ver a versão do python)
-  - python install pandas requests mysql-connector-python
+  - pip install pandas requests mysql-connector-python
   - python -c "import pandas, requests, mysql.connector; print('Tudo instalado corretamente!')"
 
 - **Consulta Base SIDRA e Gravar os Dados na Base MySQL**
-  - Baixar o arquivo "Script DML carregar base sidra_mysql.py" do repositório (https://github.com/valdecircarlos/PI_Senac/blob/main/Script%20DML%20carregar%20base%20sidra_mysql.py)
+  - Baixar o arquivo ["Script DML carregar base sidra_mysql.py"](https://github.com/valdecircarlos/PI_Senac/blob/main/Script%20DML%20carregar%20base%20sidra_mysql.py)
   - Abra o Prompt de Comando do Windows
   - Acesse o Diretório onde o arquivo de Script "Script DML carregar base sidra_mysql.py" foi salvo.
   - Executar o "Script DML carregar base sidra_mysql.py" no Prompt de comando
@@ -104,7 +104,7 @@ A extração dos dados foi feita de forma automatizada via **API do SIDRA**, uti
 - Indicadores de receita nominal e volume de vendas;
 - Segmentação por atividades do comércio varejista e ampliado.
 
-Mais informações sobre como utilizar a API do SIDRA estão disponíveis na [[documentação oficial](https://servicodados.ibge.gov.br/api/docs/sidra)](https://apisidra.ibge.gov.br/home/ajuda).
+Mais informações sobre como utilizar a API do SIDRA estão disponíveis na [documentação oficial](https://servicodados.ibge.gov.br/api/docs/sidra).
 
 ---
 


### PR DESCRIPTION
## Summary
- corrigir link de download do Power BI Desktop
- ajustar comando de instalação de bibliotecas Python
- apontar apenas um link oficial para a documentação do SIDRA
- normalizar formatação dos links no README

## Testing
- `python -m py_compile 'Script DML carregar base sidra_mysql.py'`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a1f3eab788333a6b011301dc018ac